### PR TITLE
strongswan: Make PACKAGECONFIG a default value

### DIFF
--- a/meta-networking/recipes-support/strongswan/strongswan_5.9.2.bb
+++ b/meta-networking/recipes-support/strongswan/strongswan_5.9.2.bb
@@ -24,7 +24,7 @@ EXTRA_OECONF = " \
 
 EXTRA_OECONF += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '--with-systemdsystemunitdir=${systemd_unitdir}/system/', '--without-systemdsystemunitdir', d)}"
 
-PACKAGECONFIG ??= "curl gmp openssl sqlite3 swanctl \
+PACKAGECONFIG ?= "curl gmp openssl sqlite3 swanctl \
         ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd-charon', 'charon', d)} \
 "
 PACKAGECONFIG[aesni] = "--enable-aesni,--disable-aesni,,${PN}-plugin-aesni"


### PR DESCRIPTION
Change from a weak default to a default in the definition of the PACKAGECONFIG.

In https://github.com/flihp/meta-measured/blob/master/networking-layer/recipes-support/strongswan/strongswan_5.%25.bbappend the PACKAGECONFIG is appended to, so if the definition is weak here, the variable will be empty when the bbappend attempts to add to it.